### PR TITLE
Fix "find" for paths with spaces, plus shellcheck

### DIFF
--- a/checkjndi.sh
+++ b/checkjndi.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-tld=$1
+tld="$1"
 
 if [ -z "$tld" ]; then
     tld='.'
 fi
 
-unzip=`which unzip`
+unzip=$(which unzip)
 if [ -z "$unzip" ]; then
     echo "This script requires unzip to function properly"
     exit 1
@@ -17,9 +17,9 @@ process_jar() {
     hasjndi=""
     printed=""
     if [ -z "$2" ]; then
-        parent=$1
+        parent="$1"
     else
-        parent=$2
+        parent="$2"
     fi
 
     if [ -z "$3" ]; then
@@ -29,29 +29,29 @@ process_jar() {
     fi
 
 
-    jndifile=`unzip -l $1 2> /dev/null | grep -E "JndiLookup.class$" | awk '{print $NF}'`
-    mpcfile=`unzip -l $1 2> /dev/null | grep -E "MessagePatternConverter.class$" | awk '{print $NF}'`
-    jarfiles=`unzip -l $1 2> /dev/null | grep -Ei  ".jar$|.war$|.ear$|.zip$" | grep -v "Archive: " | awk '{print $NF}'`
-    if [ ! -z "$mpcfile" ]; then
+    jndifile=$(unzip -l "$1" 2> /dev/null | grep -E "JndiLookup.class$" | awk '{print $NF}')
+    mpcfile=$(unzip -l "$1" 2> /dev/null | grep -E "MessagePatternConverter.class$" | awk '{print $NF}')
+    jarfiles=$(unzip -l "$1" 2> /dev/null | grep -Ei  ".jar$|.war$|.ear$|.zip$" | grep -v "Archive: " | awk '{print $NF}')
+    if [ -n "$mpcfile" ]; then
         outfile="$(mktemp)"
-        unzip -p $1 $mpcfile 2> /dev/null > $outfile
-        ispatched=`grep 'Message Lookups are no longer supported' $outfile`
-        if [ ! -z "$ispatched" ]; then
+        unzip -p "$1" "$mpcfile" 2> /dev/null > "$outfile"
+        ispatched=$(grep 'Message Lookups are no longer supported' "$outfile")
+        if [ -n "$ispatched" ]; then
             patched=1
         fi
     fi
 
-    if [ ! -z "$jndifile" ]; then
+    if [ -n "$jndifile" ]; then
         hasjndi=1
-        if [ ! -z "$subjarfilename" ]; then
+        if [ -n "$subjarfilename" ]; then
             outputstring="$parent contains $subjarfilename contains JndiLookup.class"
         else
             outputstring="$parent contains JndiLookup.class"
         fi
         jndioutfile="$(mktemp)"
-        unzip -p $1 $jndifile 2> /dev/null > $jndioutfile
-        ispatched=`grep 'JNDI is not supported' $jndioutfile`
-        if [ ! -z "$ispatched" ]; then
+        unzip -p "$1" "$jndifile" 2> /dev/null > "$jndioutfile"
+        ispatched=$(grep 'JNDI is not supported' "$jndioutfile")
+        if [ -n "$ispatched" ]; then
             patched=1
         fi
     fi
@@ -60,28 +60,28 @@ process_jar() {
         for subjar in $jarfiles
             do
                 subjarfile="$(mktemp)"
-                unzip -p $1 $subjar 2> /dev/null > $subjarfile
+                unzip -p "$1" "$subjar" 2> /dev/null > "$subjarfile"
                 process_jar "$subjarfile" "$parent" "$subjar"
-                rm $subjarfile 2> /dev/null
+                rm "$subjarfile" 2> /dev/null
             done
 
     fi
 
-    if [ ! -z "$mpcfile" ]; then
-        rm $outfile 2> /dev/null
+    if [ -n "$mpcfile" ]; then
+        rm "$outfile" 2> /dev/null
     fi
 
-    if [ ! -z "$jndifile" ]; then
-        rm $jndioutfile 2> /dev/null
+    if [ -n "$jndifile" ]; then
+        rm "$jndioutfile" 2> /dev/null
     fi
 
-    if [ ! -z "$patched" ]; then
+    if [ -n "$patched" ]; then
         outputstring="$outputstring ** BUT APPEARS TO BE PATCHED **"
     fi
 
     if [ -z "$printed" ]; then
-        if [ ! -z "$hasjndi" ]; then
-            if [ ! -z "$patched" ]; then
+        if [ -n "$hasjndi" ]; then
+            if [ -n "$patched" ]; then
                 echo "$outputstring"
             else
                 echo "WARNING: $outputstring"
@@ -92,9 +92,9 @@ process_jar() {
 }
 
 if [[ $OSTYPE == 'darwin'* ]]; then
-    checkfiles=`find $tld -fstype local -type f \( -iname "*.jar" -o -iname "*.war" -o -iname "*.ear" -o -iname "*.zip" -o -iname "JndiLookup.class" \)`
+    checkfiles=$(find "$tld" -fstype local -type f \( -iname "*.jar" -o -iname "*.war" -o -iname "*.ear" -o -iname "*.zip" -o -iname "JndiLookup.class" \))
 else
-    checkfiles=`find $tld -mount -type f \( -iname "*.jar" -o -iname "*.war" -o -iname "*.ear" -o -iname "*.zip" -o -iname "JndiLookup.class" \)`
+    checkfiles=$(find "$tld" -mount -type f \( -iname "*.jar" -o -iname "*.war" -o -iname "*.ear" -o -iname "*.zip" -o -iname "JndiLookup.class" \))
 fi
 
 OLDIFS=$IFS


### PR DESCRIPTION
The `find` statement was failing when there were spaces in the path. This fixes this.
Also, quote strings in case of other paths with spaces, and replace outmoded backticks with `$(...)`.