### PR TITLE
Adds pipeline input for the path to scan

### DIFF
--- a/checkjndi.ps1
+++ b/checkjndi.ps1
@@ -148,6 +148,7 @@ Begin {
 }
 
 Process {
+    Write-Verbose "Scanning $toplevel"
     $checkfiles = Get-Files $toplevel;
     ForEach ($checkfile In $checkfiles) {
         if ($checkfile.Name -eq "JndiLookup.class")

--- a/checkjndi.ps1
+++ b/checkjndi.ps1
@@ -23,129 +23,152 @@ Scans filesystem for .jar files that contains log4j code that may be vulnerable 
 #>
 [CmdletBinding()]
 param (
-    [string]$toplevel = ".", 
+    # Specifies a path to one or more locations.
+    [Parameter(Mandatory=$false,
+               Position=0,
+               ParameterSetName="Path",
+               ValueFromPipeline=$true,
+               ValueFromPipelineByPropertyName=$true,
+               HelpMessage="Path to one or more locations.")]
+    [Alias("PSPath")]
+    [ValidateNotNullOrEmpty()]
+    [string[]]
+    $toplevel = ".",
+    #[string]$toplevel = ".", 
     [switch] $Force = $false
     )
 
 #Requires -Version 3.0
 
-Add-Type -Assembly 'System.IO.Compression.FileSystem'
-
-$global:foundvulnerable = $false
-
-function Get-Files {
-    param (
-        [string]$topdir
-    )
-
-    $jars = @();
-    Get-ChildItem -Path $topdir -File -Recurse -Force:$Force -Include "*.jar","*.war","*.ear","*.zip","JndiLookup.class" -ErrorAction Ignore | % { $jars += $_ };
-    return $jars
-}
-
-function Process-JAR {
-    param (
-        [Object]$jarfile,
-        [String]$origfile = "",
-        [String]$subjarfile = ""
-    )
-    try {
-        $jar = [System.IO.Compression.ZipFile]::Open($jarfile, 'read');
+Begin {
+    Add-Type -Assembly 'System.IO.Compression.FileSystem'
+    $global:foundvulnerable = $false
+    
+    function Get-Files {
+        param (
+            [string]$topdir
+        )
+    
+        $jars = @();
+        Get-ChildItem -Path $topdir -File -Recurse -Force:$Force -Include "*.jar","*.war","*.ear","*.zip","JndiLookup.class" -ErrorAction Ignore | % { $jars += $_ };
+        return $jars
     }
-    catch {
-        Write-Warning "Unable to scan $jarfile : $($_.FullyQualifiedErrorID)" 
-        return
-    }
-    [bool] $ispatched = 0;
-    [bool] $hasjndi = 0;
-    [string] $outputstring = "";
-
-    ForEach ($entry in $jar.Entries) {
-        #Write-Output $entry.Name;
-        if($entry.Name -like "*JndiLookup.class"){
-            if ($origfile -eq "")
-            {
-                $hasjndi = 1;
-                $outputstring = "$jarfile contains $entry";
-            }
-            else
-            {
-                $hasjndi = 1;
-                $outputstring = "$origfile contains $subjarfile contains $entry";
-            }
-            $TempFile = [System.IO.Path]::GetTempFileName()
-            try {
-                Write-Verbose "Scanning $entry in $jarfile" 
-                [System.IO.Compression.ZipFileExtensions]::ExtractToFile($entry, $TempFile, $true);
-                if (Select-String -Path $TempFile -Pattern "JNDI is not supported"){
-                    $ispatched = 1;
+    
+    function Process-JAR {
+        param (
+            [Object]$jarfile,
+            [String]$origfile = "",
+            [String]$subjarfile = ""
+        )
+        try {
+            $jar = [System.IO.Compression.ZipFile]::Open($jarfile, 'read');
+        }
+        catch {
+            Write-Warning "Unable to scan $jarfile : $($_.FullyQualifiedErrorID)" 
+            return
+        }
+        [bool] $ispatched = 0;
+        [bool] $hasjndi = 0;
+        [string] $outputstring = "";
+    
+        ForEach ($entry in $jar.Entries) {
+            #Write-Output $entry.Name;
+            if($entry.Name -like "*JndiLookup.class"){
+                if ($origfile -eq "")
+                {
+                    $hasjndi = 1;
+                    $outputstring = "$jarfile contains $entry";
                 }
-            }
-            catch {
-                Write-Warning "Unable to scan $entry in $jarfile : $($_.FullyQualifiedErrorID)" 
-            }
-            Remove-Item $TempFile;
-        }
-        elseif ($entry.Name -like "*MessagePatternConverter.class"){
-            $TempFile = [System.IO.Path]::GetTempFileName()
-            try {
-                [System.IO.Compression.ZipFileExtensions]::ExtractToFile($entry, $TempFile, $true);
-                if (Select-String -Path $TempFile -Pattern "Message Lookups are no longer supported"){
-                    $ispatched = 1;
+                else
+                {
+                    $hasjndi = 1;
+                    $outputstring = "$origfile contains $subjarfile contains $entry";
                 }
+                $TempFile = [System.IO.Path]::GetTempFileName()
+                try {
+                    Write-Verbose "Scanning $entry in $jarfile" 
+                    [System.IO.Compression.ZipFileExtensions]::ExtractToFile($entry, $TempFile, $true);
+                    if (Select-String -Path $TempFile -Pattern "JNDI is not supported"){
+                        $ispatched = 1;
+                    }
+                }
+                catch {
+                    Write-Warning "Unable to scan $entry in $jarfile : $($_.FullyQualifiedErrorID)" 
+                }
+                Remove-Item $TempFile;
             }
-            catch {
-                Write-Warning "Unable to scan $entry in $jarfile : $($_.FullyQualifiedErrorID)" 
+            elseif ($entry.Name -like "*MessagePatternConverter.class"){
+                $TempFile = [System.IO.Path]::GetTempFileName()
+                try {
+                    [System.IO.Compression.ZipFileExtensions]::ExtractToFile($entry, $TempFile, $true);
+                    if (Select-String -Path $TempFile -Pattern "Message Lookups are no longer supported"){
+                        $ispatched = 1;
+                    }
+                }
+                catch {
+                    Write-Warning "Unable to scan $entry in $jarfile : $($_.FullyQualifiedErrorID)" 
+                }
+                Remove-Item $TempFile;
             }
-            Remove-Item $TempFile;
+            elseif (($entry.Name -like "*.jar") -or ($entry.Name -like "*.war") -or ($entry.Name -like "*.ear") -or ($entry.Name -like "*.zip")) {
+                if ($origfile -eq "")
+                {
+                    $origfile = $jarfile.FullName
+                }
+                $TempFile = [System.IO.Path]::GetTempFileName()
+                try {
+                    [System.IO.Compression.ZipFileExtensions]::ExtractToFile($entry, $TempFile, $true);
+                    Process-JAR $TempFile $origfile $entry.FullName;
+                }
+                catch{
+                    Write-Warning "Unable to scan $entry in $jarfile : $($_.FullyQualifiedErrorID)" 
+                }
+                Remove-Item $TempFile;
+    
+            }
         }
-        elseif (($entry.Name -like "*.jar") -or ($entry.Name -like "*.war") -or ($entry.Name -like "*.ear") -or ($entry.Name -like "*.zip")) {
-            if ($origfile -eq "")
-            {
-                $origfile = $jarfile.FullName
-            }
-            $TempFile = [System.IO.Path]::GetTempFileName()
-            try {
-                [System.IO.Compression.ZipFileExtensions]::ExtractToFile($entry, $TempFile, $true);
-                Process-JAR $TempFile $origfile $entry.FullName;
-            }
-            catch{
-                Write-Warning "Unable to scan $entry in $jarfile : $($_.FullyQualifiedErrorID)" 
-            }
-            Remove-Item $TempFile;
+        $jar.Dispose();
+        if ($ispatched){
+            $outputstring = $outputstring + " ** BUT APPEARS TO BE PATCHED **";
+        }
+        if ($hasjndi -and $ispatched){
+            Write-Host $outputstring;
+        }
+        elseif ($hasjndi){
+            $global:foundvulnerable = $true
+            Write-Warning $outputstring;
+        }
+    
+    }
 
+    if (-not $Force) {
+        Write-Warning "-Force not used, will not scan System or Hidden files."
+    }
+    
+}
+
+Process {
+    $checkfiles = Get-Files $toplevel;
+    ForEach ($checkfile In $checkfiles) {
+        if ($checkfile.Name -eq "JndiLookup.class")
+        {
+            Write-Host "$checkfile *IS* JndiLookup.class"
+        }
+        else
+        {
+            Process-JAR $checkfile;
         }
     }
-    $jar.Dispose();
-    if ($ispatched){
-        $outputstring = $outputstring + " ** BUT APPEARS TO BE PATCHED **";
-    }
-    if ($hasjndi -and $ispatched){
-        Write-Host $outputstring;
-    }
-    elseif ($hasjndi){
-        $global:foundvulnerable = $true
-        Write-Warning $outputstring;
-    }
-
 }
 
-if (-not $Force) {
-    Write-Warning "-Force not used, will not scan System or Hidden files."
+End {
+
+    if ($global:foundvulnerable -eq $false) {
+        "No vulnerable components found"
+    }
+    
 }
 
-$checkfiles = Get-Files $toplevel;
-ForEach ($checkfile In $checkfiles) {
-    if ($checkfile.Name -eq "JndiLookup.class")
-    {
-        Write-Host "$checkfile *IS* JndiLookup.class"
-    }
-    else
-    {
-        Process-JAR $checkfile;
-    }
-}
 
-if ($global:foundvulnerable -eq $false) {
-    "No vulnerable components found"
-}
+
+


### PR DESCRIPTION
Adds the ability to accept paths to scan on the pipeline.
Opens up additional flexibility for people to include/exclude paths, or to use their own list of paths.
This does not change the current parameter behavior.

Scan everything in the current user's Documents folder, except for files/folders starting with "log":
`ls ~\Documents\ -Exclude 'log*' | .\checkjndi.ps1  -Force -Verbose`
Would help for https://github.com/CERTCC/CVE-2021-44228_scanner/issues/22

Scan the root of all drives accessible to the PowerShell instance: 
`Get-PSProvider -PSProvider 'FileSystem' | select-Object -Expandproperty Drives | Select-Object -ExpandProperty Root | .\checkjndi`
Should help to resolve https://github.com/CERTCC/CVE-2021-44228_scanner/issues/24

Scan a list of paths in a file:
` get-content .\paths.txt | .\checkjndi.ps1`
