### PR TITLE
Add metadata required to publish to a local PowerShell Script Repository.

### DIFF
--- a/checkjndi.ps1
+++ b/checkjndi.ps1
@@ -1,4 +1,5 @@
-<#
+<#PSScriptInfo
+
 .VERSION 1.0.0
 
 .GUID db424b6a-fdee-48e0-b0d5-3949e07c2ef6

--- a/checkjndi.ps1
+++ b/checkjndi.ps1
@@ -1,4 +1,11 @@
 <#
+.VERSION 1.0.0
+
+.GUID db424b6a-fdee-48e0-b0d5-3949e07c2ef6
+
+.AUTHOR  https://github.com/CERTCC
+
+.PROJECTURI https://github.com/CERTCC/CVE-2021-44228_scanner
 
 .Description
 Scans filesystem for .jar, war, and ear files that contains log4j code that may be vulnerable to CVE-2021-44228


### PR DESCRIPTION
Makes script compatible with the requirements for Publish-Script to enable publishing to internal PowerShell repositories.
This will make it easier for orgs with restrictions on outbound access to deploy an up-to-date version of checkjndi.ps1 to a local repository, which can be used on machines without internet access. 