### PR TITLE
Better reporting of paths that cannot be enumerated with Get-Childitem

### DIFF
--- a/checkjndi.ps1
+++ b/checkjndi.ps1
@@ -1,6 +1,6 @@
 <#PSScriptInfo
 
-.VERSION 1.0.1
+.VERSION 1.0.2
 
 .GUID db424b6a-fdee-48e0-b0d5-3949e07c2ef6
 

--- a/checkjndi.ps1
+++ b/checkjndi.ps1
@@ -56,8 +56,10 @@ Begin {
         param (
             [string]$topdir
         )
- 
-        Get-ChildItem -Path $topdir -File -Recurse -Force:$Force -Include "*.jar","*.war","*.ear","*.zip","JndiLookup.class" -ErrorAction SilentlyContinue
+            Get-ChildItem -Path $topdir -File -Recurse -Force:$Force -Include "*.jar","*.war","*.ear","*.zip","JndiLookup.class" -ErrorAction SilentlyContinue -ErrorVariable UnscannablePaths
+            foreach ($Exception in $UnscannablePaths) {
+                Write-Warning "Unable to scan $($Exception.TargetObject) : $($Exception.FullyQualifiedErrorID)"
+            }
     }
     
     function Process-JAR {


### PR DESCRIPTION
This may actually finally put #5 to bed.
It doesn't fix the fact that the directories can't be enumerated, but it does ensure that they're reported properly.
Not sure if Write-Warning or Write-Error is more appropriate for this case, but since write-warning is used already for failures to open archives, I stuck with that.