### PR TITLE
Update checkjndi.ps1

### DIFF
--- a/checkjndi.ps1
+++ b/checkjndi.ps1
@@ -64,7 +64,7 @@ Begin {
 
     function Process-JAR {
         param (
-            [Object]$jarfile,
+            [String]$jarfile,
             [String]$origfile = "",
             [String]$subjarfile = ""
         )
@@ -125,7 +125,7 @@ Begin {
             elseif (($entry.Name -like "*.jar") -or ($entry.Name -like "*.war") -or ($entry.Name -like "*.ear") -or ($entry.Name -like "*.zip")) {
                 if ($origfile -eq "")
                 {
-                    $origfile = $jarfile.FullName;
+                    $origfile = $jarfile; #recurse embedded archive
                 }
                 $TempFile = [System.IO.Path]::GetTempFileName();
                 try {


### PR DESCRIPTION
$jarfile is really a string, so line 128 would throw an exception when embedded archives are found [also updated Process-JAR parameter type]