### PR TITLE
Simplify file extension comparison in checkjndi.ps1

### DIFF
--- a/checkjndi.ps1
+++ b/checkjndi.ps1
@@ -56,7 +56,7 @@ Begin {
         param (
             [string]$topdir
         )
-            Get-ChildItem -Path $topdir -File -Recurse -Force -ErrorAction SilentlyContinue -ErrorVariable UnscannablePaths | Where-Object {($_.extension -eq ".jar") -or ($_.extension -eq ".war") -or ($_.extension -eq ".ear") -or ($_.extension -eq ".zip") -or ($_.Name -eq "JndiLookup.class")}
+            Get-ChildItem -Path $topdir -File -Recurse -Force -ErrorAction SilentlyContinue -ErrorVariable UnscannablePaths | Where-Object {($_.extension -in (".jar",".war",".ear",".zip")) -or ($_.Name -eq "JndiLookup.class")}
             foreach ($Exception in $UnscannablePaths) {
                 Write-Warning "Unable to scan $($Exception.TargetObject) : $($Exception.FullyQualifiedErrorID)";
             }


### PR DESCRIPTION
Instead of chaining together `($_.Extension -eq '.foo') -or ($_.Extension -eq '.bar')` statements, you can use the `-in` comparison operator and provide an array of strings to check against: `$_.Extension -in ('.foo', '.bar')` This makes visualizing and editing the list easier and keeps the code concise, while still being readable.

Another advantage to this method is that, later, you could parameterize that array of extensions and pass it in as an argument to the script. Although, I won't include that functionality in this pull request.